### PR TITLE
module/dir-overlay: keep the directory structure while copying files

### DIFF
--- a/dir-overlay/module/dir-overlay
+++ b/dir-overlay/module/dir-overlay
@@ -68,7 +68,7 @@ case "$STATE" in
         if [ -e $manifest_file ]; then
             mkdir -p $backup_dir
             for file in $(cat $manifest_file); do
-                cp $dest_dir/$file $backup_dir/
+                tar cf - $dest_dir/$file | (cd $backup_dir/ && tar xf -)
             done
             tar -cf ${prev_files_tar} -C ${backup_dir} .
 


### PR DESCRIPTION
Without this commit, if 'mender -rollback' is called, all the files
are installed ont top of the root in a non-recursively
way (e.g /app.conf or /data.txt instead of /etc/app.conf or /usr/share/app/data.txt).

Thus, the rollback is not correct because the old files are not
reinstalled in the right place.

Fixes:

root@nitrogen8m:/var/lib/mender/dir-overlay-install# tar xvf backup.tar
./
./app.conf
./data.txt
./app

Now:

root@nitrogen8m:/var/lib/mender/dir-overlay-install# tar xvf backup.tar
./
./etc/
./etc/app.conf
./usr/
./usr/bin/
./usr/bin/app
./usr/share/
./usr/share/app/
./usr/share/app/data.txt

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>