### PR TITLE
module/dir-overlay: fix bashism in rollback state

### DIFF
--- a/dir-overlay/module/dir-overlay
+++ b/dir-overlay/module/dir-overlay
@@ -91,7 +91,7 @@ case "$STATE" in
     ArtifactRollback)
         dest_dir=$(cat $dest_dir_file)
 
-        [[ -f $prev_files_tar ]] || exit 0
+        test -f $prev_files_tar || exit 0
 
         cp $manifest_file_prev $manifest_file
         tar -xf ${prev_files_tar} -C ${dest_dir}


### PR DESCRIPTION
Fixes:

$: checkbashisms dir-overlay
possible bashism in dir-overlay line 94 (alternative test command ([[ foo ]] should be [ foo ])):
        [[ -f $prev_files_tar ]] || exit 0

Reported-by: Evan Speelman <speeltronics@gmail.com>
Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>