### PR TITLE
dir-overlay: preserve file/directory ownership and mode permissions

### DIFF
--- a/dir-overlay/module-artifact-gen/dir-overlay-artifact-gen
+++ b/dir-overlay/module-artifact-gen/dir-overlay-artifact-gen
@@ -148,7 +148,7 @@ case $dest_dir in
 esac
 
 if [ -d "${file_tree}" ]; then
-  tar -cf ${update_files_tar} -C "${file_tree}" .
+  tar --same-owner -cpf ${update_files_tar} -C "${file_tree}" .
 else
   echo "Error: \"${file_tree}\" is not a directory or does not exit. Aborting."
   exit 1

--- a/dir-overlay/module/dir-overlay
+++ b/dir-overlay/module/dir-overlay
@@ -68,9 +68,9 @@ case "$STATE" in
         if [ -e $manifest_file ]; then
             mkdir -p $backup_dir
             for file in $(cat $manifest_file); do
-                tar cf - $dest_dir/$file | (cd $backup_dir/ && tar xf -)
+                tar -cpf - $dest_dir/$file | (cd $backup_dir/ && tar -xpf -)
             done
-            tar -cf ${prev_files_tar} -C ${backup_dir} .
+            tar -cpf ${prev_files_tar} -C ${backup_dir} .
 
             for file in $(cat $manifest_file); do
                 rm $dest_dir/$file
@@ -80,7 +80,7 @@ case "$STATE" in
         fi
 
         mkdir -p ${dest_dir}
-        tar -xf ${update_files_tar} -C ${dest_dir}
+        tar -xpf ${update_files_tar} -C ${dest_dir}
         sync
         ;;
 
@@ -94,7 +94,7 @@ case "$STATE" in
         test -f $prev_files_tar || exit 0
 
         cp $manifest_file_prev $manifest_file
-        tar -xf ${prev_files_tar} -C ${dest_dir}
+        tar -xpf ${prev_files_tar} -C ${dest_dir}
         ;;
 esac
 

--- a/dir-overlay/module/dir-overlay
+++ b/dir-overlay/module/dir-overlay
@@ -62,11 +62,21 @@ case "$STATE" in
     ;;
 
     ArtifactInstall)
+        if [ $UID -ne 0 ] ; then
+            echo "This update module must be run by a superuser. Aborting..."
+            exit 1
+        fi
+
         dest_dir=$(cat $dest_dir_file)
         mkdir -p $dest_dir $state_dir
 
         if [ -e $manifest_file ]; then
             mkdir -p $backup_dir
+
+            # Copy permissions and ownership from destination directory
+            chmod $(stat -c %a $dest_dir) $backup_dir
+            chown $(stat -c "%U:%G" $dest_dir) $backup_dir
+
             for file in $(cat $manifest_file); do
                 tar -cpf - $dest_dir/$file | (cd $backup_dir/ && tar -xpf -)
             done
@@ -85,10 +95,18 @@ case "$STATE" in
         ;;
 
     ArtifactCommit)
+        if [ $UID -ne 0 ] ; then
+            echo "This update module must be run by a superuser. Aborting..."
+            exit 1
+        fi
         mv $manifest_file_from_deployment $manifest_file
         ;;
 
     ArtifactRollback)
+        if [ $UID -ne 0 ] ; then
+            echo "This update module must be run by a superuser. Aborting..."
+            exit 1
+        fi
         dest_dir=$(cat $dest_dir_file)
 
         test -f $prev_files_tar || exit 0


### PR DESCRIPTION
This means that the properties that are set in the input directory,
will be preserved on the target device once installed.

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>