### PR TITLE
add 'dfu' Update Module

### DIFF
--- a/dfu/README.md
+++ b/dfu/README.md
@@ -1,0 +1,53 @@
+## Description
+
+The DFU Update Module is able to update peripheral devices connected to the device running Mender.
+
+Example use-cases:
+* Deploy firmware updates to peripheral devices using the USB Device Firmware Update (DFU) protocol
+
+For a more detailed tutorial on how to use this Update Module please visit [Mender Hub](https://hub.mender.io/t/device-firmware-update-dfu)
+
+### Specification
+
+|||
+| --- | --- |
+|Module name| dfu |
+|Supports rollback|no|
+|Requires restart|no|
+|Artifact generation script|yes|
+|Full system updater|no|
+|Source code|[Update Module](https://github.com/mendersoftware/mender-update-modules/tree/master/dfu/module/dfu), [Artifact Generator](https://github.com/mendersoftware/mender-update-modules/blob/master/dfu/module-artifact-gen/dfu-artifact-gen)|
+
+### Install the Update Module
+
+Download the latest version of this Update Module by running:
+
+```
+mkdir -p /usr/share/mender/modules/v3 && wget -P /usr/share/mender/modules/v3 https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/dfu/module/dfu && chmod +x /usr/share/mender/modules/v3/dfu
+```
+
+### Create artifact
+
+To download `dfu-artifact-gen`, run the following:
+
+```
+wget https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/dfu/module-artifact-gen/dfu-artifact-gen && chmod +x dfu-artifact-gen
+```
+
+Generate Mender Artifacts using the following command:
+
+```
+ARTIFACT_NAME="my-update-1.0"
+DEVICE_TYPE="my-device-type"
+./dfu-artifact-gen --artifact-name ${ARTIFACT_NAME} \
+                   --device-type ${DEVICE_TYPE} \
+                   --firmware-file <path to firmware file>
+```
+
+### Maintainer
+
+The author and maintainer of this Update Module is:
+
+- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
+
+Always include the original author when suggesting code changes to this update module.

--- a/dfu/module-artifact-gen/dfu-artifact-gen
+++ b/dfu/module-artifact-gen/dfu-artifact-gen
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+set -e
+
+show_help() {
+  cat << EOF
+
+Simple tool to generate Mender Artifact suitable for dfu Update Module
+
+Usage: $0 [options] [-- [options-for-mender-artifact] ]
+
+    Options: [ -f|--firmware-file -n|--artifact-name -t|--device-type -h|--help ]
+
+        --artifact-name     - Artifact name
+        --device-type       - Target device type identification (can be given more than once)
+        --firmware-file     - Firmware file that will be written to the device using dfu-util
+        --help              - Show help and exit
+
+Anything after a '--' gets passed directly to the mender-artifact tool.
+
+EOF
+}
+
+show_help_and_exit_error() {
+  show_help
+  exit 1
+}
+
+check_dependency() {
+  hash "$1" || exit 1
+}
+
+check_dependency mender-artifact
+
+device_types=""
+artifact_name=""
+firmware_file=""
+passthrough=0
+passthrough_args=""
+
+while (( "$#" )); do
+  if test $passthrough -eq 1
+  then
+    passthrough_args="$passthrough_args $1"
+    shift
+    continue
+  fi
+  case "$1" in
+    --device-type | -t)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      device_types="$device_types $1 $2"
+      shift 2
+      ;;
+    --artifact-name | -n)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      artifact_name=$2
+      shift 2
+      ;;
+    --firmware-file | -f)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      firmware_file=$2
+      shift 2
+      ;;
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --)
+      passthrough=1
+      shift
+      ;;
+    *)
+      echo "Error: unsupported option $1"
+      show_help_and_exit_error
+      ;;
+  esac
+done
+
+if [ -z "${artifact_name}" ]; then
+  echo "Artifact name not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+output_path="${artifact_name}.mender"
+
+if [ -z "${device_types}" ]; then
+  echo "Device type not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+mender-artifact write module-image \
+  -T dfu \
+  $device_types \
+  -o $output_path \
+  -n $artifact_name \
+  -f $firmware_file \
+  $passthrough_args
+
+echo "Artifact $output_path generated successfully:"
+mender-artifact read $output_path
+
+exit 0

--- a/dfu/module/dfu
+++ b/dfu/module/dfu
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+
+STATE="$1"
+FILES="$2"
+
+firmware_path="$FILES/files/"
+
+case "$STATE" in
+
+    NeedsArtifactReboot)
+        echo "No"
+    ;;
+
+    SupportsRollback)
+        echo "No"
+    ;;
+
+    ArtifactInstall)
+        firmware_file=$(ls ${firmware_path})
+        if [ ${#firmware_file[@]} -gt 1 ]; then
+            echo "Expected to find only one firmware file, but found: ${firmware_file}"
+            exit 1
+        fi
+
+        # Here you would ensure that your peripheral device enters DFU mode
+        # prior to running the dfu-util. This module was developed using a
+        # reference device which was always in DFU mode.
+        #
+        # How to enter DFU mode is application specific, and hence left out
+        # in this reference module
+
+        dfu-util --alt 1 --download "${firmware_path}"/"${firmware_file}"
+        ;;
+
+    # ArtifactRollback state could be implemented here, but this is highly
+    # application specific and does not fit in to this reference module
+esac
+
+exit 0


### PR DESCRIPTION
The DFU Update Module is a reference Update Module that demonstrates
how to update firmware of a peripheral device using the
Device Firmware Update USB device class.

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>