### PR TITLE
dfu: fix lookup of firmware file

### DIFF
--- a/dfu/module/dfu
+++ b/dfu/module/dfu
@@ -18,11 +18,7 @@ case "$STATE" in
     ;;
 
     ArtifactInstall)
-        firmware_file=$(ls ${firmware_path})
-        if [ ${#firmware_file[@]} -gt 1 ]; then
-            echo "Expected to find only one firmware file, but found: ${firmware_file}"
-            exit 1
-        fi
+        firmware_file=$(find ${firmware_path} -type f | head -1)
 
         # Here you would ensure that your peripheral device enters DFU mode
         # prior to running the dfu-util. This module was developed using a
@@ -31,7 +27,7 @@ case "$STATE" in
         # How to enter DFU mode is application specific, and hence left out
         # in this reference module
 
-        dfu-util --alt 1 --download "${firmware_path}"/"${firmware_file}"
+        dfu-util --alt 1 --download "${firmware_file}"
         ;;
 
     # ArtifactRollback state could be implemented here, but this is highly


### PR DESCRIPTION
It seems that the script contained some bashism and did
not work when dash was set as shell (which is the case on
Raspbian)

Simplified the logic, and just pick the first file found
in the payload (there should only be one).

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>