### PR TITLE
Rootfs updates with a version check

### DIFF
--- a/rootfs-version-check/README.md
+++ b/rootfs-version-check/README.md
@@ -1,0 +1,48 @@
+## Description
+
+The rootfs-version-check Update Module implements a full image update with additional checks to protect against replay attacks.
+
+This is functionally equivalent to the built-in full image update with an extra check to ensure the artifact name follows a specific
+format and that installing "older" images is rejected.  For this reference implementaton, we simply use a numeric identifier and ensure
+that it is larger than the version installed.  For actual device fleet use, you may need to customize this based on your artifact
+naming scheme.
+
+Example use-cases:
+* Deploy root filesystem updates and ensure only newer artifacts are installed
+
+For a more detailed tutorial on how to use this Update Module please visit [Mender Hub](https://hub.mender.io/t/rootfs-version-check/)
+
+### Specification
+
+|||
+| --- | --- |
+|Module name| rootfs-version-check |
+|Supports rollback|yes|
+|Requires restart|yes|
+|Artifact generation script|no|
+|Full system updater|yes|
+|Source code|[Update Module](https://github.com/mendersoftware/mender-update-modules/tree/master/rootfs-version-check/module/rootfs-version-check)|
+
+### Install the Update Module
+
+Download the latest version of this Update Module by running:
+
+    mkdir -p /usr/share/mender/modules/v3 && wget -P /usr/share/mender/modules/v3 https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/rootfs-version-check/module/rootfs-version-check && chmod +x /usr/share/mender/modules/v3/rootfs-version-check
+
+### Create artifact
+
+Generate Mender Artifacts using the following command:
+
+    ARTIFACT_NAME="my-update-1.0"
+    DEVICE_TYPE="my-device-type"
+    OUTPUT_PATH="my-update-1.0.mender"
+    IMAGE="rootfs.ext4"
+    mender-artifact write module-image -T rootfs-version-check -n ${ARTIFACT_NAME} -t ${DEVICE_TYPE} -o ${OUTPUT_PATH} -f ${IMAGE}
+
+### Maintainer
+
+The author and maintainer of this Update Module is:
+
+- Drew Moseley - <drew.moseley@northern.tech> - [drewmoseley](https://github.com/drewmoseley)
+
+Always include the original author when suggesting code changes to this update module.

--- a/rootfs-version-check/mender-compare-versions
+++ b/rootfs-version-check/mender-compare-versions
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+#
+
+import sys
+
+if len(sys.argv) != 3:
+    print("Usage: %s new_version old_version" % sys.argv[0])
+    sys.exit(1)
+
+# Default is to disallow installation
+rc = 1
+
+try:
+    # This assumes the version names are of the form prefix:number
+    # Where prefix is any text.  We simply split on the ':' and
+    # select the last item as the numeric version
+    new_version = sys.argv[1].split(":")[-1]
+    old_version = sys.argv[2].split(":")[-1]
+
+    if int(new_version) > int(old_version):
+        # The new version ordinal is greater.  Allow installation.
+        rc = 0
+except:
+    # Unable to parse the version strings.  Default disallow.
+    pass
+
+sys.exit(rc)

--- a/rootfs-version-check/module/rootfs-version-check
+++ b/rootfs-version-check/module/rootfs-version-check
@@ -20,8 +20,25 @@ else
     passive_num=$MENDER_ROOTFS_PART_A_NUMBER
 fi
 
+compare_versions_or_exit() {
+    local COMPARE_VERSIONS="/usr/share/utils/mender-compare-versions"
+
+    if [ ! -x "${COMPARE_VERSIONS}" ]; then
+        echo "Unable to locate mender-compare-versions executable."
+        exit 1
+    fi
+    # This script needs to be provided by the integrator and customized specifically for their naming scheme.
+    if ! "${COMPARE_VERSIONS}" "$(cat header/artifact_name)" "$(cat current_artifact_name)"; then
+        echo "Refusing to install $(cat header/artifact_name) over current version $(cat current_artifact_name)."
+        exit 1
+    fi
+
+    echo "Allowing installation of $(cat header/artifact_name) over current version $(cat current_artifact_name)."
+}
+
 case "$1" in
     Download)
+        compare_versions_or_exit()
         file="$(cat stream-next)"
         cat "$file" > $passive
         if [ "$(cat stream-next)" != "" ]; then
@@ -63,6 +80,7 @@ EOF
         ;;
 
     ArtifactCommit)
+        compare_versions_or_exit()
         fw_setenv upgrade_available 0
         ;;
 

--- a/rootfs-version-check/module/rootfs-version-check
+++ b/rootfs-version-check/module/rootfs-version-check
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+set -ue
+
+# Is expected to contain two variable definitions with device paths:
+# - MENDER_ROOTFS_PART_A
+# - MENDER_ROOTFS_PART_B
+. /etc/mender/rootfs-version-check.conf
+
+MENDER_ROOTFS_PART_A_NUMBER="$(echo "$MENDER_ROOTFS_PART_A" | egrep -o '[0-9]+$')"
+MENDER_ROOTFS_PART_B_NUMBER="$(echo "$MENDER_ROOTFS_PART_B" | egrep -o '[0-9]+$')"
+
+active_num="$(fw_printenv mender_boot_part)"
+active_num="${active_num#mender_boot_part=}"
+if test $active_num -eq $MENDER_ROOTFS_PART_A_NUMBER; then
+    passive=$MENDER_ROOTFS_PART_B
+    passive_num=$MENDER_ROOTFS_PART_B_NUMBER
+else
+    passive=$MENDER_ROOTFS_PART_A
+    passive_num=$MENDER_ROOTFS_PART_A_NUMBER
+fi
+
+case "$1" in
+    Download)
+        file="$(cat stream-next)"
+        cat "$file" > $passive
+        if [ "$(cat stream-next)" != "" ]; then
+            echo "More than one file in payload"
+            exit 1
+        fi
+        ;;
+
+    ArtifactInstall)
+        fw_setenv -s - <<EOF
+mender_boot_part $passive_num
+upgrade_available 1
+bootcount 0
+EOF
+        ;;
+
+    PerformsFullUpdate)
+        echo "Yes"
+        ;;
+
+    NeedsArtifactReboot)
+        echo "Automatic"
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    ArtifactVerifyReboot)
+        if test "$(fw_printenv upgrade_available)" != "upgrade_available=1"; then
+            exit 1
+        fi
+        ;;
+
+    ArtifactVerifyRollbackReboot)
+        if test "$(fw_printenv upgrade_available)" = "upgrade_available=1"; then
+            exit 1
+        fi
+        ;;
+
+    ArtifactCommit)
+        fw_setenv upgrade_available 0
+        ;;
+
+    ArtifactRollback)
+        if test "$(fw_printenv upgrade_available)" = "upgrade_available=1"; then
+            fw_setenv -s - <<EOF
+mender_boot_part $passive_num
+upgrade_available 0
+EOF
+        fi
+        ;;
+esac
+exit 0


### PR DESCRIPTION
This update module is essentially identical to the [rootfsv2 one](https://hub.mender.io/t/root-filesystem-image-v2/402/7) with the addition of a callout to /usr/bin/rootfs-version-check that can be used to enforce ordering on the client side.