### PR TITLE
rootfs-version-check: Fix incorrect bash function call syntax.

### DIFF
--- a/rootfs-version-check/module/rootfs-version-check
+++ b/rootfs-version-check/module/rootfs-version-check
@@ -38,7 +38,7 @@ compare_versions_or_exit() {
 
 case "$1" in
     Download)
-        compare_versions_or_exit()
+        compare_versions_or_exit
         file="$(cat stream-next)"
         cat "$file" > $passive
         if [ "$(cat stream-next)" != "" ]; then
@@ -80,7 +80,7 @@ EOF
         ;;
 
     ArtifactCommit)
-        compare_versions_or_exit()
+        compare_versions_or_exit
         fw_setenv upgrade_available 0
         ;;
 


### PR DESCRIPTION
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>