### PR TITLE
feat: add snap installer Update Module

### DIFF
--- a/install_snap/README.md
+++ b/install_snap/README.md
@@ -1,0 +1,56 @@
+## Description
+
+The install_snap Update Module is able install packages to the device running Mender using
+the snap tooling.
+
+Example use-cases:
+
+* managing devices running the [snap](https://snapcraft.io/) app store, specifically Ubuntu
+
+### Specification
+
+|||
+| --- | --- |
+|Module name| install_snap |
+|Supports rollback|no|
+|Requires restart|no|
+|Artifact generation script|yes|
+|Full system updater|no|
+|Source code|[Update Module](https://github.com/mendersoftware/mender-update-modules/tree/master/install_snap/module/install_snap), [Artifact Generator](https://github.com/mendersoftware/mender-update-modules/blob/master/install_snap/module-artifact-gen/install_snap-artifact-gen)|
+
+### Install the Update Module
+
+Download the latest version of this Update Module by running:
+
+```
+mkdir -p /usr/share/mender/modules/v3 && wget -P /usr/share/mender/modules/v3 https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/install_snap/module/install_snap && chmod +x /usr/share/mender/modules/v3/install_snap
+```
+
+### Create artifact
+
+To download `install_snap-artifact-gen`, run the following:
+
+```
+wget https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/install_snap/module-artifact-gen/install_snap-artifact-gen && chmod +x install_snap-artifact-gen
+```
+
+Generate Mender Artifacts using the following command:
+
+```
+ARTIFACT_NAME="my-update-1.0"
+DEVICE_TYPE="my-device-type"
+./install_snap-artifact-gen \
+    --artifact-name ${ARTIFACT_NAME} \
+    --device-type ${DEVICE_TYPE} \
+    <name of snap> ...
+```
+
+This tool depends on the `snap` CLI.
+
+### Maintainer
+
+The author and maintainer of this Update Module is:
+
+- Josef Holzmayr - <josef.holzmayr@northern.tech> - [theyoctojester](https://github.com/theyoctojester)
+
+Always include the original author when suggesting code changes to this update module.

--- a/install_snap/module-artifact-gen/install_snap-artifact-gen
+++ b/install_snap/module-artifact-gen/install_snap-artifact-gen
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -e
+
+show_help() {
+  cat << EOF
+
+Simple tool to generate Mender Artifact suitable for install_snap Update Module
+
+Usage: $0 [options] SNAP [SNAPS...] [-- [options-for-mender-artifact] ]
+
+    Options: [ -n|artifact-name -t|--device-type -o|--output_path -h|--help ]
+
+        --artifact-name     - Artifact name
+        --device-type       - Target device type identification (can be given more than once)
+        --output-path       - Path to output file. Default: install_snap-artifact.mender
+        --help              - Show help and exit
+        SNAP                - snap name(s) to add to the Artifact
+
+Anything after a '--' gets passed directly to the mender-artifact tool.
+
+EOF
+}
+
+show_help_and_exit_error() {
+  show_help
+  exit 1
+}
+
+check_dependency() {
+  if ! which "$1" > /dev/null; then
+    echo "The $1 utility is not found but required to generate Artifacts." 1>&2
+    return 1
+  fi
+}
+
+if ! check_dependency mender-artifact; then
+  echo "Please follow the instructions here to install mender-artifact and then try again: https://docs.mender.io/downloads#mender-artifact" 1>&2
+  exit 1
+fi
+check_dependency snap
+check_dependency jq
+
+device_types=""
+artifact_name=""
+output_path="install_snap-artifact.mender"
+meta_data_file="meta-data.json"
+SNAPS=""
+passthrough=0
+passthrough_args=""
+
+while (( "$#" )); do
+  if test $passthrough -eq 1
+  then
+    passthrough_args="$passthrough_args $1"
+    shift
+    continue
+  fi
+  case "$1" in
+    --device-type | -t)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      device_types="$device_types $1 $2"
+      shift 2
+      ;;
+    --artifact-name | -n)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      artifact_name=$2
+      shift 2
+      ;;
+    --output-path | -o)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      output_path=$2
+      shift 2
+      ;;
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --)
+      passthrough=1
+      shift
+      ;;
+    -*)
+      echo "Error: unsupported option $1"
+      show_help_and_exit_error
+      ;;
+    *)
+      SNAPS="$SNAPS $1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${artifact_name}" ]; then
+  echo "Artifact name not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+if [ -z "${device_types}" ]; then
+  echo "Device type not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+if [ -z "${SNAPS}" ]; then
+  echo "At least one snap must be specified. Aborting."
+  show_help_and_exit_error
+fi
+
+snaps=""
+for snap in $SNAPS; do
+  if ! snap info $snap >/dev/null 2>&1; then
+    echo "The ${snap} snap is not valid. Aborting."
+    show_help_and_exit_error
+  fi
+  snaps="$snaps \"${snap}\""
+done
+snaps=$(echo $snaps | tr ' ' ',')
+
+eval "jq -n --argjson c '[$snaps]' '{\"snaps\": \$c}'" > $meta_data_file
+
+mender-artifact write module-image \
+  -T install_snap \
+  $device_types \
+  -o $output_path \
+  -n $artifact_name \
+  -m $meta_data_file \
+  $passthrough_args
+
+echo "Artifact $output_path generated successfully:"
+mender-artifact read $output_path
+
+exit 0

--- a/install_snap/module/install_snap
+++ b/install_snap/module/install_snap
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+STATE="$1"
+FILES="$2"
+
+case "$STATE" in
+
+    NeedsArtifactReboot)
+        echo "No"
+        ;;
+
+    SupportsRollback)
+        echo "No"
+        ;;
+
+    Download)
+        command -v snap >/dev/null 2>&1 || { echo >&2 "ERROR: Must have snap installed to run this update module."; exit 1; }
+        ;;
+
+    ArtifactInstall)
+        for snap in $(jq -r ".snaps[]" "$FILES"/header/meta-data); do
+            >&2 echo "Installing new snap [$snap]"
+            snap install $snap
+        done
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
This update module can be used to install one or multiple snap packages on the target device. It uses the configured repositories on the target and transports only the metadata.

Changelog: Title
Ticket: None