### PR TITLE
feat: add "dirty" Update Module template

### DIFF
--- a/dirty/README.md
+++ b/dirty/README.md
@@ -1,0 +1,72 @@
+## Description
+
+The dirty Update Module: modify your device state without installing an artifact
+
+Example use-cases:
+
+* you have a specific action on the device that you want to run multiple times
+* you want to avoid re-creating artifacts just for the sake of a new version/name
+* you don't want the artifact the show up in the list of installed artifacts
+
+The module will *always* fail the update process, which means it can never be marked
+as installed. So it can be attempted any number of times without having to recreate
+newly versioned artifacts.
+
+Benefits:
+* you can put your desired operation into the `dirty_action` function
+* after the (failed) deployment, you can check if your operation
+  * finished successfully: the update failed in `ArtifactCommit`
+  * resulted in an error: the update failed in `ArfifactInstall`
+
+### Specification
+
+|||
+| --- | --- |
+|Module name| dirty |
+|Supports rollback|no|
+|Requires restart|no|
+|Artifact generation script|yes|
+|Full system updater|no|
+|Source code|[Update Module](https://github.com/mendersoftware/mender-update-modules/tree/master/dirty/module/dirty), [Artifact Generator](https://github.com/mendersoftware/mender-update-modules/blob/master/dirty/module-artifact-gen/dirty-artifact-gen)|
+
+### Install the example Update Module
+
+Download the latest version of this Update Module by running:
+
+```
+mkdir -p /usr/share/mender/modules/v3 && wget -P /usr/share/mender/modules/v3 https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/dirty/module/dirty && chmod +x /usr/share/mender/modules/v3/dirty
+```
+
+The example will add a string to the `/tmp/dirty` file as demonstration of an action.
+
+### Package your "dirty" operation
+
+The example structure provides all necessary states and a `dirty_action` stub function. The operation to
+occur should be implemented in the `dirty_action` stub, and return
+* `0` upon successful completion
+* `!= 0` upon error
+
+### Create artifact
+
+To download `dirty-artifact-gen`, run the following:
+
+```
+wget https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/dirty/module-artifact-gen/dirty-artifact-gen && chmod +x dirty-artifact-gen
+```
+
+Generate Mender Artifacts using the following command:
+
+```
+ARTIFACT_NAME="my-update-1.0"
+DEVICE_TYPE="my-device-type"
+./reboot-artifact-gen --artifact-name ${ARTIFACT_NAME} \
+                      --device-type ${DEVICE_TYPE}
+```
+
+### Maintainer
+
+The author and maintainer of this Update Module is:
+
+- Josef Holzmayr - <josef.holzmayr@northern.tech>
+
+Always include the original author when suggesting code changes to this update module.

--- a/dirty/module-artifact-gen/dirty-artifact-gen
+++ b/dirty/module-artifact-gen/dirty-artifact-gen
@@ -1,0 +1,114 @@
+#!/bin/sh
+
+set -e
+
+show_help() {
+  cat << EOF
+
+Simple tool to generate Mender Artifact suitable for the dirty Update Module
+
+Usage: $0 [options] [-- [options-for-mender-artifact] ]
+
+    Options: [ -n|artifact-name -t|--device-type -o|--output_path -h|--help ]
+
+        --artifact-name     - Artifact name
+        --device-type       - Target device type identification (can be given more than once)
+        --output-path       - Path to output artifact file. Default: reboot-artifact.mender
+        --help              - Show help and exit
+
+Anything after a '--' gets passed directly to the mender-artifact tool.
+
+EOF
+}
+
+show_help_and_exit_error() {
+  show_help
+  exit 1
+}
+
+check_dependency() {
+  if ! which "$1" > /dev/null; then
+    echo "The $1 utility is not found but required to generate Artifacts." 1>&2
+    return 1
+  fi
+}
+
+if ! check_dependency mender-artifact; then
+  echo "Please follow the instructions here to install mender-artifact and then try again: https://docs.mender.io/downloads#mender-artifact" 1>&2
+  exit 1
+fi
+
+device_types=""
+artifact_name=""
+output_path="dirty-artifact.mender"
+passthrough=0
+passthrough_args=""
+
+while [ -n "$1" ]; do
+  if test $passthrough -eq 1
+  then
+    passthrough_args="$passthrough_args $1"
+    shift
+    continue
+  fi
+  case "$1" in
+    --device-type | -t)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      device_types="$device_types $1 $2"
+      shift 2
+      ;;
+    --artifact-name | -n)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      artifact_name=$2
+      shift 2
+      ;;
+    --output-path | -o)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      output_path=$2
+      shift 2
+      ;;
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --)
+      passthrough=1
+      shift
+      ;;
+    -*)
+      echo "Error: unsupported option $1"
+      show_help_and_exit_error
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${artifact_name}" ]; then
+  echo "Artifact name not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+if [ -z "${device_types}" ]; then
+  echo "Device type not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+mender-artifact write module-image \
+  -T dirty \
+  $device_types \
+  -o $output_path \
+  -n $artifact_name \
+  $passthrough_args
+
+echo "Artifact $output_path generated successfully:"
+mender-artifact read $output_path
+
+exit 0

--- a/dirty/module/dirty
+++ b/dirty/module/dirty
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -e
+
+STATE="$1"
+
+# This is just an example operation that *intentionally* modifies something
+# in the filesystem. You can put any desired action here.
+# The key requirement is that it returns
+# - 0 on success
+# - != 0 on failure 
+dirty_action() {
+    echo "date: $(date), state: $STATE" >> /tmp/dirty
+    return $?
+}
+
+case "$STATE" in
+    NeedsArtifactReboot)
+        echo "No"
+        ;;
+    SupportsRollback)
+        echo "No"
+        ;;
+    Download)
+        exit 0
+        ;;
+    ArtifactInstall)
+        dirty_action
+        exit $?
+        ;;
+        # This is the second part of the dirty trick: the update will *always* fail in
+        # the ArtifactCommit state. It is reached if the operation in ArtifactInstall
+        # completed successfully. So if you read the deployment failure log, you can
+        # see if your operation resulted in
+        # - error: the failure state is ArtifactInstall
+        # - success: the failure state is ArtifactCommit.
+    ArtifactCommit)
+        exit 1
+        ;;
+esac
+
+exit 0
+


### PR DESCRIPTION
The dirty Update Module template is an example on how to perform an operation on the device without the artifact being installed. This allows for repeating the process without the need to generate new artifacts. Also, the Artifact will not show up as installed.

Changelog: Title
Ticket: None