### PR TITLE
fix: bashim in dfu-artifact-gen without matching shebang

### DIFF
--- a/dfu/module-artifact-gen/dfu-artifact-gen
+++ b/dfu/module-artifact-gen/dfu-artifact-gen
@@ -44,7 +44,7 @@ firmware_file=""
 passthrough=0
 passthrough_args=""
 
-while (( "$#" )); do
+while [ -n "$1" ]; do
   if test $passthrough -eq 1
   then
     passthrough_args="$passthrough_args $1"


### PR DESCRIPTION
The expressing `while (( ... ))` requires the shell being invoked as bash. Replacing it with the more generic `while [ -n ... ]`.

Ticket: None
Changelog: Title