### PR TITLE
swu: Update Module wrapper for SWUpdate

### DIFF
--- a/swu/README.md
+++ b/swu/README.md
@@ -1,0 +1,61 @@
+## Description
+
+The SWU Update Module allows deploying an SWUpdate-based artifact to the device
+
+Example use-cases:
+* extend an existing platform using SWUpdate with OTA
+
+### Specification
+
+|||
+| --- | --- |
+|Module name| swu |
+|Supports rollback| no |
+|Requires restart| configurable |
+|Artifact generation script| yes |
+|Full system updater| no |
+|Source code|[Update Module](https://github.com/mendersoftware/mender-update-modules/tree/master/swu/module/swu)|
+
+### Install the Update Module
+
+Download the latest version of this Update Module by running:
+
+    mkdir -p /usr/share/mender/modules/v3 && wget -P /usr/share/mender/modules/v3 https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/swu/module/swu && chmod +x /usr/share/mender/modules/v3/swu
+
+### Create artifact
+
+To download `swu-artifact-gen`, run the following:
+
+```
+wget https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/install_snap/module-artifact-gen/install_snap-artifact-gen && chmod +x swu-artifact-gen
+```
+
+Generate Mender Artifacts using the following command:
+
+```
+ARTIFACT_NAME="my-update-1.0"
+DEVICE_TYPE="my-device-type"
+./swu-artifact-gen \
+    --artifact-name ${ARTIFACT_NAME} \
+    --device-type ${DEVICE_TYPE} \
+    <name of swu file(s)> ...
+```
+
+### Optional reboot
+
+The SWU Update Module supports rebooting after artifact installation. If this is required for the packaged SWU file(s), add the `--reboot` flag to the `swu-artifact-gen` invocation.
+
+### Possible future improvements
+
+- rollback support
+- automatic determination of metadata from SWU file(s)
+- enforced ordering of multiple SWUs
+- streaming support
+
+### Maintainer
+
+The author and maintainer of this Update Module is:
+
+- Josef Holzmayr - <josef.holzmayr@northern.tech> - [theyoctojester](https://github.com/theyoctojester)
+
+Always include the original author when suggesting code changes to this update module.

--- a/swu/module-artifact-gen/swu-artifact-gen
+++ b/swu/module-artifact-gen/swu-artifact-gen
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -e
+
+show_help() {
+  cat << EOF
+
+Simple tool to generate Mender Artifact suitable for SWU Update Module
+
+Usage: $0 [options] SWU [SWU...] [-- [options-for-mender-artifact] ]
+
+    Options: [ -n|artifact-name -t|--device-type -o|--output_path -h|--help ]
+
+        --artifact-name     - Artifact name
+        --device-type       - Target device type identification (can be given more than once)
+        --output-path       - Path to output file. Default: swu-artifact.mender
+        --reboot            - Installation requires a reboot
+        --help              - Show help and exit
+        SWU                 - SWU file(s) to add to the Artifact
+
+Anything after a '--' gets passed directly to the mender-artifact tool.
+
+EOF
+}
+
+show_help_and_exit_error() {
+  show_help
+  exit 1
+}
+
+check_dependency() {
+  if ! which "$1" > /dev/null; then
+    echo "The $1 utility is not found but required to generate Artifacts." 1>&2
+    return 1
+  fi
+}
+
+if ! check_dependency mender-artifact; then
+  echo "Please follow the instructions here to install mender-artifact and then try again: https://docs.mender.io/downloads#mender-artifact" 1>&2
+  exit 1
+fi
+check_dependency jq
+
+device_types=""
+artifact_name=""
+output_path="swu-artifact.mender"
+meta_data_file="meta-data.json"
+SWUS=""
+passthrough=0
+passthrough_args=""
+reboot="false"
+
+while (( "$#" )); do
+  if test $passthrough -eq 1
+  then
+    passthrough_args="$passthrough_args $1"
+    shift
+    continue
+  fi
+  case "$1" in
+    --device-type | -t)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      device_types="$device_types $1 $2"
+      shift 2
+      ;;
+    --artifact-name | -n)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      artifact_name=$2
+      shift 2
+      ;;
+    --output-path | -o)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      output_path=$2
+      shift 2
+      ;;
+	--reboot)
+	  reboot="true"
+	  shift
+	  ;;
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --)
+      passthrough=1
+      shift
+      ;;
+    -*)
+      echo "Error: unsupported option $1"
+      show_help_and_exit_error
+      ;;
+    *)
+      SWUS="$SWUS $1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${artifact_name}" ]; then
+  echo "Artifact name not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+if [ -z "${device_types}" ]; then
+  echo "Device type not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+if [ -z "${SWUS}" ]; then
+  echo "At least one swu file must be specified. Aborting."
+  show_help_and_exit_error
+fi
+
+eval "jq -n --argjson c '$reboot' '{\"reboot\": \$c}'" > $meta_data_file
+
+echo "final SWUS: \"$SWUS\""
+
+mender-artifact write module-image \
+  -T swu \
+  $device_types \
+  -o $output_path \
+  -n $artifact_name \
+  -m $meta_data_file \
+  $(echo "$SWUS" | sed -e 's/ / -f /g')
+  $passthrough_args
+
+echo "Artifact $output_path generated successfully:"
+mender-artifact read $output_path
+
+exit 0

--- a/swu/module/swu
+++ b/swu/module/swu
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+STATE="$1"
+FILES="$2"
+
+case "$STATE" in
+
+    NeedsArtifactReboot)
+		REBOOT=$(jq -r ".reboot" "$FILES"/header/meta-data)
+		if [ "$REBOOT" = "true" ]; then
+			echo "Automatic";
+		else
+        	echo "No";
+		fi
+        ;;
+    ArtifactInstall)
+        swupdate -i "$FILES"/files/*.swu
+        ;;
+esac
+exit 0


### PR DESCRIPTION
There is a variety of client-only solutions for installing update artifacts to embedded Linux devices, such as SWupdate or RAUC which do not offer a remote management solution. Those can be wrapped in an Update Module to enable OTA deployments, while keeping known good working integrations intact.

Example use-cases:
* Brownfield migration of existing device fleets using a client-only update solution
* Wrapping a custom flashing solution, as sometimes required for special hardware

This Update Module provides a sample implementation to deploy SWUpdate artifacts using Mender, but it can be easily adapted to other client solutions.

Changelog: Title
Ticket: None