### PR TITLE
Add mender podman module

### DIFF
--- a/podman/README.md
+++ b/podman/README.md
@@ -1,0 +1,111 @@
+### Description
+
+The Podman Update Module handles the Podman container images that shall be running on the target device. A deployment with this module will stop all currently running Podman containers on the device and start new containers based on the list of Podman images provided in the Mender Artifact.
+
+In case of any unforeseen error during the process, the module will trigger the rollback mechanism of the Mender client to restore the previously running Podman containers.
+
+### Specification
+|||
+| --- | --- |
+|Module name|podman|
+|Supports rollback|yes|
+|Requires restart|no|
+|Artifact generation script|yes|
+|Full operating system updater|no|
+|Source code|[Update Module](https://github.com/mendersoftware/mender-update-modules/tree/master/podman/module/podman), [Artifact Generator](https://github.com/mendersoftware/mender-update-modules/tree/master/podman/module-artifact-gen/podman-artifact-gen)|
+|Maintainer|Community|
+
+## Prepare the device
+
+This section describes how to setup your target device, i.e. the device to be updated. This will also be referred to as the device environment.
+
+All commands outlined in this section should be run in the device environment.
+
+### Prerequisites
+
+This update module has the following prerequisites for the device environment:
+
+* [Install Podman](https://podman.io/getting-started/installation)
+* A recent version of the JSON parser `jq` must be installed on the device.
+* The device must have a Bash Unix shell available.
+
+How to install these depends on which OS you are running.
+
+### Install the Update Module
+
+Download the latest version of this Update Module by running:
+
+```bash
+mkdir -p /usr/share/mender/modules/v3 && wget -P /usr/share/mender/modules/v3 https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/podman/module/podman
+```
+
+## Prepare the development environment on your workstation
+
+This section describes how to set up your development environment on your workstation.
+
+All commands outlined in this section should be run in the development environment.
+
+### Prerequisites
+
+This Update Module has the following prerequisites for the development environment:
+
+* [Install mender-artifact ](https://docs.mender.io/downloads), version 3.1.0 or later
+
+### Artifact creation
+
+For convenience, an Artifact generator tool `podman-artifact-gen` is provided along the module. This tool will generate Mender Artifacts in the same format that the Update Module expects them.
+
+Download `podman-artifact-gen`, by running the following command:
+
+```bash
+wget https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/podman/module-artifact-gen/podman-artifact-gen
+```
+
+Make it executable:
+
+```bash
+chmod +x podman-artifact-gen
+```
+
+Now generate a Mender Artifact using the following command:
+
+```bash
+ARTIFACT_NAME="my-container-update-1.0"
+DEVICE_TYPE="my-device-type"
+OUTPUT_PATH=my-container-update-1.0.mender
+PODMAN_IMAGES="podman-image-1 podman-image2"
+./podman-artifact-gen -n ${ARTIFACT_NAME} -t ${DEVICE_TYPE} -o ${OUTPUT_PATH} ${PODMAN_IMAGES}
+```
+
+* `ARTIFACT_NAME`  - The name of the Mender Artifact
+* `DEVICE_TYPE`  - The compatible device type of this Mender Artifact
+* `OUTPUT_PATH`  - The path where to place the output Mender Artifact. This should always have a  `.mender`  suffix
+* `PODMAN_IMAGES` - The list of Podman images that we want the target to run. Each item can be any valid name for Podman to pull images from (tags or digests). For example debian, debian:jessie, debian:latest, debian:sha256@…, etc
+
+Note that the actual image id that will be added in the Artifact is the digest (sha256 hash) of the image, regardless of the tag used to pull it in. This will ensure that the device will pull the exact same version of each image than the generation tool used when preparing the Artifact.
+
+You can either deploy this Artifact in managed mode with the Mender server (upload it under Releases in the server UI) or by using the Mender client only in [Standalone deployments](https://docs.mender.io/artifact-creation/standalone-deployment).
+
+#### Artifact technical details
+
+The Mender Artifact used by this Update Module has no payload files. Instead it uses the `Metadata` field to list the Podman images, which will be downloaded by the device. This meta-data is composed by a single `containers` JSON key with the array of images digests to be installed in the update.
+
+As an example, the following update will install two specific versions of Podman images debian and ubuntu:
+
+```bash
+Updates:
+  - Type: podman
+    Provides:
+      rootfs-image.podman.version: my-container-update-1.0
+    Depends: {}
+    Clears Provides: [rootfs-image.podman.*]
+    Metadata:
+      {
+        "containers": [
+          "debian@sha256:e11072c1614c08bf88b543fcfe09d75a0426d90896408e926454e88078274fcb",
+          "ubuntu@sha256:99c35190e22d294cdace2783ac55effc69d32896daaa265f0bbedbcde4fbe3e5"
+        ],
+        "run_args": ""
+      }
+    Files: []
+```

--- a/podman/module-artifact-gen/podman-artifact-gen
+++ b/podman/module-artifact-gen/podman-artifact-gen
@@ -19,6 +19,7 @@ Usage: $0 [options] IMAGE [IMAGES...] [-- [options-for-mender-artifact] ]
         --software-filesystem - If specified, is used instead of rootfs-image
         --run-args            - Command line args to add when running the container(s)
         --output-path         - Path to output file. Default: podman-artifact.mender
+        --platform            - Platform to use for the artifact (default: linux/amd64)
         --help                - Show help and exit
         IMAGE [IMAGES...]     - Podman container images to add to the Artifact
 
@@ -90,6 +91,13 @@ while [ -n "$1" ]; do
       output_path=$2
       shift 2
       ;;
+    --platform)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      platform=$2
+      shift 2
+      ;;
     -h | --help)
       show_help
       exit 0
@@ -127,7 +135,11 @@ fi
 
 HASHES=""
 for image in $IMAGES; do
-    podman pull $image
+    if [ -n "$platform" ]; then
+        podman pull --platform $platform $image
+    else
+        podman pull $image
+    fi
     HASHES="$HASHES\"$(podman inspect --format='{{index .RepoDigests 0}}' $image)\" "
 done
 HASHES=$(echo $HASHES | tr ' ' ',')

--- a/podman/module-artifact-gen/podman-artifact-gen
+++ b/podman/module-artifact-gen/podman-artifact-gen
@@ -1,0 +1,177 @@
+#!/bin/sh
+
+set -e
+
+show_help() {
+  cat << EOF
+
+Simple tool to generate Mender Artifact suitable for podman Update Module
+
+Usage: $0 [options] IMAGE [IMAGES...] [-- [options-for-mender-artifact] ]
+
+    Options: [ -n|artifact-name -t|--device-type --software-name --software-version --software-filesystem --run-args -o|--output_path -h|--help ]
+
+        --artifact-name       - Artifact name
+        --device-type         - Target device type identification (can be given more than once)
+        --software-name       - Name of the key to store the software version: rootfs-image.NAME.version,
+                                instead of rootfs-image.podman.version
+        --software-version    - Value for the software version, defaults to the name of the artifact
+        --software-filesystem - If specified, is used instead of rootfs-image
+        --run-args            - Command line args to add when running the container(s)
+        --output-path         - Path to output file. Default: podman-artifact.mender
+        --help                - Show help and exit
+        IMAGE [IMAGES...]     - Podman container images to add to the Artifact
+
+Anything after a '--' gets passed directly to the mender-artifact tool.
+
+EOF
+}
+
+show_help_and_exit_error() {
+  show_help
+  exit 1
+}
+
+check_dependency() {
+  if ! command -v "$1" > /dev/null; then
+    echo "The $1 utility is not found but required to generate Artifacts." 1>&2
+    return 1
+  fi
+}
+
+if ! check_dependency mender-artifact; then
+  echo "Please follow the instructions here to install mender-artifact and then try again: https://docs.mender.io/downloads#mender-artifact" 1>&2
+  exit 1
+fi
+check_dependency podman
+check_dependency jq
+
+device_types=""
+artifact_name=""
+output_path="podman-artifact.mender"
+meta_data_file="meta-data.json"
+IMAGES=""
+passthrough_args=""
+
+while [ -n "$1" ]; do
+  case "$1" in
+    --device-type | -t)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      device_types="$device_types $1 $2"
+      shift 2
+      ;;
+    --artifact-name | -n)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      artifact_name=$2
+      shift 2
+      ;;
+    --software-name | --software-version | --software-filesystem)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      passthrough_args="$passthrough_args $1 $2"
+      shift 2
+      ;;
+    --run-args)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      run_args=$2
+      shift 2
+      ;;
+    --output-path | -o)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      output_path=$2
+      shift 2
+      ;;
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --)
+      shift
+      passthrough_args="$passthrough_args $@"
+      break
+      ;;
+    -*)
+      echo "Error: unsupported option $1"
+      show_help_and_exit_error
+      ;;
+    *)
+      IMAGES="$IMAGES $1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${artifact_name}" ]; then
+  echo "Artifact name not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+if [ -z "${device_types}" ]; then
+  echo "Device type not specified. Aborting."
+  show_help_and_exit_error
+fi
+
+if [ -z "${IMAGES}" ]; then
+  echo "At least one Podman image must be specified. Aborting."
+  show_help_and_exit_error
+fi
+
+HASHES=""
+for image in $IMAGES; do
+    podman pull $image
+    HASHES="$HASHES\"$(podman inspect --format='{{index .RepoDigests 0}}' $image)\" "
+done
+HASHES=$(echo $HASHES | tr ' ' ',')
+
+eval "jq -n --argjson c '[$HASHES]' '{\"containers\": \$c, \"run_args\": \"${run_args}\"}'" > $meta_data_file
+
+# Check the the passthrough_args and potentially modify them
+# to avoid conflicts or to let them override the already args
+# provided to mender-artifact
+# # Runs in a subshell to allow overriding some parameters passed
+# to mender-artifact
+passthrough_args_modified=" "
+echo -n $passthrough_args | xargs -n 2 printf "%s %s\n" | (while read -r flag arg; do
+  if [ -n "$flag" ] && [ -n "$arg" ]; then
+    case $flag in
+      -T | --type | -m | --meta-data)
+        echo "Error: Conflicting flag '$flag'. Already specified by the script."
+        exit 1
+        ;;
+      -o | --output-path)
+        output_path=$arg
+        ;;
+      -n | --name)
+        artifact_name=$arg
+        ;;
+      *)
+        passthrough_args_modified="$passthrough_args_modified $flag $arg"
+        ;;
+    esac
+  fi
+done
+
+mender-artifact write module-image \
+  -T podman \
+  $device_types \
+  -o $output_path \
+  -n $artifact_name \
+  -m $meta_data_file \
+  $passthrough_args_modified
+
+
+echo "Artifact $output_path generated successfully:"
+mender-artifact read $output_path
+# End of subshell
+)
+rm $meta_data_file
+exit 0

--- a/podman/module/podman
+++ b/podman/module/podman
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -e
+
+STATE="$1"
+FILES="$2"
+
+prev_containers_file="$FILES"/tmp/prev_containers.list
+
+case "$STATE" in
+
+    NeedsArtifactReboot)
+        echo "No"
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    Download)
+        command -v podman >/dev/null 2>&1 || { echo >&2 "ERROR: Must have podman installed to run this update module."; exit 1; }
+        ;;
+
+    ArtifactInstall)
+        >&2 echo "Storing reference on running containers for rollback needs to $prev_containers_file"
+        podman ps -q > $prev_containers_file
+
+        >&2 echo "Stopping all running containers"
+        [ -n "$(cat $prev_containers_file)" ] && podman stop $(cat $prev_containers_file)
+
+        run_args=$(jq -r ".run_args | select (.!=null)" "$FILES"/header/meta-data)
+        for container in $(jq -r ".containers[]" "$FILES"/header/meta-data); do
+            >&2 echo "Pulling new container [$container]"
+            podman pull $container
+            >&2 echo "Starting new container [$container] with args [${run_args}]"
+            podman run -dt ${run_args} $container
+        done
+        ;;
+
+    ArtifactRollback)
+        >&2 echo "Container update rollback started"
+        [ -f $prev_containers_file ] ||  (>&2 echo "ERROR: Failed to find rollback reference file [$prev_containers_file]" && exit 1)
+        >&2 echo "Stopping all running containers"
+        [ -n  "$(podman ps -q)" ] && podman stop $(podman ps -q)
+        >&2 echo "Starting containers running prior to the update"
+        [ -n "$(cat $prev_containers_file)" ] && podman start $(cat $prev_containers_file)
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
This is a proposal to add a podman module to mender update.
When used in embedded platforms, podman is a nice way to solve some of Docker issues, and well supported.

The artifact generator and the dedicated podman module are very similar to what is done with docker.
One thing added is the possibility to pass a platform different to the one by default (linux/amd64).
Testing on RPi4b showed an issue with networking, though. It is possible to bypass it by generating the artifact with an additional run-args to force network=host but it is not very nice :-).

Tested the following:
On host:
`$> mender-update-modules/podman/module-artifact-gen/podman-artifact-gen -n "docker-hello-mender-1.0" --platform linux/arm64 -t raspberrypi4-64 -o docker-hello-mender.mender --run-args --network=host alpine`
`$> scp docker-hello-mender.mender ${TARGET}:/tmp/`

On target:
`~# mender-update install /tmp/docker-hello-mender.mender `
Installing artifact...
record_id=1 severity=info time="2025-Feb-27 14:47:54.776034" name="Global" msg="Update Module output (stderr): Storing reference on running containers for rollback needs to /var/lib/mender/modules/v3/payloads/0000/tree/tmp/prev_containers.list" 
record_id=2 severity=info time="2025-Feb-27 14:47:54.868258" name="Global" msg="Update Module output (stderr): Stopping all running containers" 
record_id=3 severity=info time="2025-Feb-27 14:47:54.889879" name="Global" msg="Update Module output (stderr): Pulling new container [docker.io/library/alpine@sha256:757d680068d77be46fd1ea20fb21db16f150468c5e7079a08a2e4705aec096ac]" 
record_id=4 severity=info time="2025-Feb-27 14:47:54.968422" name="Global" msg="Update Module output (stderr): Trying to pull docker.io/library/alpine@sha256:757d680068d77be46fd1ea20fb21db16f150468c5e7079a08a2e4705aec096ac..." 
record_id=5 severity=info time="2025-Feb-27 14:48:02.113587" name="Global" msg="Update Module output (stderr): Getting image source signatures" 
record_id=6 severity=info time="2025-Feb-27 14:48:02.114210" name="Global" msg="Update Module output (stderr): Copying blob sha256:6e771e15690e2fabf2332d3a3b744495411d6e0b00b2aea64419b58b0066cf81" 
record_id=7 severity=info time="2025-Feb-27 14:48:02.117682" name="Global" msg="Update Module output (stderr): Copying config sha256:8d591b0b7dea080ea3be9e12ae563eebf9869168ffced1cb25b2470a3d9fe15e" 
record_id=8 severity=info time="2025-Feb-27 14:48:02.155957" name="Global" msg="Update Module output (stderr): Writing manifest to image destination" 
record_id=9 severity=info time="2025-Feb-27 14:48:02.194997" name="Global" msg="Update Module output (stdout): 8d591b0b7dea080ea3be9e12ae563eebf9869168ffced1cb25b2470a3d9fe15e" 
record_id=10 severity=info time="2025-Feb-27 14:48:02.203857" name="Global" msg="Update Module output (stderr): Starting new container [docker.io/library/alpine@sha256:757d680068d77be46fd1ea20fb21db16f150468c5e7079a08a2e4705aec096ac] with args [--network=host]" 
record_id=11 severity=info time="2025-Feb-27 14:48:02.778325" name="Global" msg="Update Module output (stdout): 045fab7dce38f8c782b2ba60f81e68554d290aca0a090f50442ca96706f6a2f0" 
Installed, but not committed.

