### PR TITLE
feat: Add persistent-app update module for data partition deployments

### DIFF
--- a/persistent-app/README.md
+++ b/persistent-app/README.md
@@ -1,0 +1,91 @@
+# Persistent App Update Module
+
+## Description
+
+The Persistent App Update Module installs files to a user-defined directory on the persistent data partition, ensuring deployments survive rootfs A/B updates.
+
+This module uses the `data-partition` software filesystem namespace, which means version tracking in `mender show-provides` persists across system updates. When a rootfs update clears `rootfs-image.*` provides, the `data-partition.*` provides remain intact.
+
+The module supports rollback by maintaining backups on the same persistent partition.
+
+Example use-cases:
+* Deploy application files that must persist across OS updates
+* Deploy configuration bundles to /data
+* Deploy container images, ML models, or other large files to persistent storage
+
+For a detailed tutorial on persistent update modules, visit [Mender Hub](https://hub.mender.io).
+
+### Specification
+
+|||
+| --- | --- |
+|Module name| persistent-app |
+|Supports rollback|yes|
+|Requires restart|no|
+|Artifact generation script|yes|
+|Full system updater|no|
+|Source code|[Update Module](https://github.com/mendersoftware/mender-update-modules/tree/master/persistent-app/module/persistent-app), [Artifact Generator](https://github.com/mendersoftware/mender-update-modules/blob/master/persistent-app/module-artifact-gen/persistent-app-artifact-gen)|
+
+### Install the Update Module
+
+Download the latest version of this Update Module by running:
+
+```bash
+mkdir -p /usr/share/mender/modules/v3 && wget -P /usr/share/mender/modules/v3 https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/persistent-app/module/persistent-app && chmod +x /usr/share/mender/modules/v3/persistent-app
+```
+
+### Create artifact
+
+To download `persistent-app-artifact-gen`, run the following:
+
+```bash
+wget https://raw.githubusercontent.com/mendersoftware/mender-update-modules/master/persistent-app/module-artifact-gen/persistent-app-artifact-gen && chmod +x persistent-app-artifact-gen
+```
+
+Generate Mender Artifacts using the following command:
+
+```bash
+ARTIFACT_NAME="myapp-v1.0.0"
+DEVICE_TYPE="raspberrypi4"
+DEST_DIR="/data/myapp"
+SOFTWARE_NAME="myapp"
+SOFTWARE_VERSION="1.0.0"
+OUTPUT_PATH="myapp-v1.0.0.mender"
+./persistent-app-artifact-gen \
+    -n ${ARTIFACT_NAME} \
+    -t ${DEVICE_TYPE} \
+    -d ${DEST_DIR} \
+    --software-name ${SOFTWARE_NAME} \
+    --software-version ${SOFTWARE_VERSION} \
+    -o ${OUTPUT_PATH} \
+    ./payload/
+```
+
+The artifact generator automatically includes `--software-filesystem data-partition` to ensure version tracking survives rootfs updates.
+
+**Note on directory structure:** The artifact generator flattens all input files into a single directory. If you pass a directory like `./payload/` containing `bin/app` and `etc/config.json`, both files end up directly in the destination directory (e.g., `/data/myapp/app` and `/data/myapp/config.json`), not in subdirectories. This module is intended as a simple example; for complex directory hierarchies, consider using the [dir-overlay](../dir-overlay) module or adapting this module to your needs.
+
+After deploying, verify with:
+
+```bash
+mender show-provides | grep data-partition
+# Output: data-partition.myapp.version=1.0.0
+```
+
+### How it works
+
+1. **ArtifactInstall**: The module backs up any existing content at the destination directory to `<dest_dir>.backup`, then copies the new files.
+
+2. **ArtifactCommit**: On successful deployment, the backup is removed.
+
+3. **ArtifactRollback**: If the deployment fails or is rejected, the backup is restored.
+
+4. **Persistence**: Both the deployed files and the backup reside on the data partition (typically `/data`), which is not affected by rootfs A/B updates.
+
+### Maintainer
+
+The author and maintainer of this Update Module is:
+
+- Josef Holzmayr - <jester@theyoctojester.info> - [TheYoctoJester](https://github.com/TheYoctoJester)
+
+Always include the original author when suggesting code changes to this update module.

--- a/persistent-app/module-artifact-gen/persistent-app-artifact-gen
+++ b/persistent-app/module-artifact-gen/persistent-app-artifact-gen
@@ -1,0 +1,228 @@
+#!/bin/bash
+
+set -e
+
+show_help() {
+  cat << EOF
+
+Tool to generate Mender Artifacts for the persistent-app Update Module
+
+This module deploys files to the persistent data partition, ensuring they
+survive rootfs A/B updates. Uses the data-partition software filesystem
+namespace for version tracking that persists across system updates.
+
+Usage: $0 [options] input-files... [-- [options-for-mender-artifact]]
+
+    Options:
+
+        -n, --artifact-name     Artifact name (required)
+        -t, --device-type       Target device type (required, repeatable)
+        -d, --dest-dir          Destination directory on device (required)
+                                Must be an absolute path, typically under /data
+        -o, --output-path       Path to output file (default: persistent-app.mender)
+        --software-name         Software name for provides (optional)
+        --software-version      Software version for provides (optional)
+        -h, --help              Show help and exit
+
+        input-files             Files or directories to include in the artifact
+
+    Anything after '--' is passed directly to mender-artifact.
+
+Example:
+
+    $0 -n myapp-v1.0.0 -t raspberrypi4 -d /data/myapp \\
+       --software-name myapp --software-version 1.0.0 \\
+       -o myapp-v1.0.0.mender ./payload/
+
+EOF
+}
+
+show_help_and_exit_error() {
+  show_help
+  exit 1
+}
+
+check_dependency() {
+  if ! which "$1" > /dev/null; then
+    echo "Error: $1 is required but not found." 1>&2
+    return 1
+  fi
+}
+
+if ! check_dependency mender-artifact; then
+  echo "Please install mender-artifact: https://docs.mender.io/downloads/workstation-tools#mender-artifact" 1>&2
+  exit 1
+fi
+
+declare -a device_types
+artifact_name=""
+dest_dir=""
+output_path="persistent-app.mender"
+software_name=""
+software_version=""
+declare -a input_files
+passthrough=0
+declare -a passthrough_args
+
+while (( "$#" )); do
+  if test $passthrough -eq 1; then
+    passthrough_args+=("$1")
+    shift
+    continue
+  fi
+  case "$1" in
+    --device-type | -t)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      device_types+=("-t" "$2")
+      shift 2
+      ;;
+    --artifact-name | -n)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      artifact_name=$2
+      shift 2
+      ;;
+    --dest-dir | -d)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      dest_dir=$2
+      shift 2
+      ;;
+    --output-path | -o)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      output_path=$2
+      shift 2
+      ;;
+    --software-name)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      software_name=$2
+      shift 2
+      ;;
+    --software-version)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
+      software_version=$2
+      shift 2
+      ;;
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --)
+      passthrough=1
+      shift
+      ;;
+    -*)
+      echo "Error: unsupported option $1"
+      show_help_and_exit_error
+      ;;
+    *)
+      input_files+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "${artifact_name}" ]; then
+  echo "Error: Artifact name not specified."
+  show_help_and_exit_error
+fi
+
+if [ ${#device_types[@]} -eq 0 ]; then
+  echo "Error: Device type not specified."
+  show_help_and_exit_error
+fi
+
+if [ -z "${dest_dir}" ]; then
+  echo "Error: Destination directory not specified."
+  show_help_and_exit_error
+fi
+
+if [ ${#input_files[@]} -eq 0 ]; then
+  echo "Error: No input files specified."
+  show_help_and_exit_error
+fi
+
+# Check dest-dir is an absolute path
+case $dest_dir in
+  /*)
+    ;;
+  *)
+    echo "Error: Destination directory must be an absolute path."
+    exit 1
+  ;;
+esac
+
+# Warn about flattening behavior with multiple inputs
+if [ ${#input_files[@]} -gt 1 ]; then
+  echo "Warning: Multiple input files/directories specified. All files will be flattened into a single directory." >&2
+  echo "         Directory structure will NOT be preserved. See README for details." >&2
+fi
+
+# Create temporary working directory
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+# Create dest_dir marker file
+echo "$dest_dir" > "$work_dir/dest_dir"
+
+# Build file arguments for mender-artifact
+declare -a file_args
+file_args+=("-f" "$work_dir/dest_dir")
+
+# Process input files
+for item in "${input_files[@]}"; do
+  if [ -e "$item" ]; then
+    if [ -d "$item" ]; then
+      # Copy directory contents
+      for file in "$item"/*; do
+        if [ -e "$file" ]; then
+          cp -a "$file" "$work_dir/"
+          file_args+=("-f" "$work_dir/$(basename "$file")")
+        fi
+      done
+    else
+      # Copy single file
+      cp -a "$item" "$work_dir/"
+      file_args+=("-f" "$work_dir/$(basename "$item")")
+    fi
+  else
+    echo "Warning: $item does not exist, skipping."
+  fi
+done
+
+# Build software version arguments
+declare -a software_args
+if [ -n "$software_name" ]; then
+  software_args+=("--software-name" "$software_name")
+fi
+if [ -n "$software_version" ]; then
+  software_args+=("--software-version" "$software_version")
+fi
+
+# Generate the artifact
+# CRITICAL: --software-filesystem data-partition ensures provides survive rootfs updates
+mender-artifact write module-image \
+  -T persistent-app \
+  "${device_types[@]}" \
+  -o "$output_path" \
+  -n "$artifact_name" \
+  --software-filesystem data-partition \
+  "${software_args[@]}" \
+  "${file_args[@]}" \
+  "${passthrough_args[@]}"
+
+echo "Artifact $output_path generated successfully:"
+mender-artifact read "$output_path"
+
+exit 0

--- a/persistent-app/module/persistent-app
+++ b/persistent-app/module/persistent-app
@@ -1,0 +1,117 @@
+#!/bin/sh
+
+set -e
+
+STATE="$1"
+FILES="$2"
+
+# Logging to stderr (stdout reserved for Mender protocol responses)
+log() {
+    echo "persistent-app: $1" >&2
+}
+
+# Read destination directory from artifact (required, no default)
+dest_dir_file="$FILES/files/dest_dir"
+if [ ! -f "$dest_dir_file" ]; then
+    log "Error: dest_dir file missing from artifact"
+    exit 1
+fi
+dest_dir=$(cat "$dest_dir_file")
+backup_dir="${dest_dir}.backup"
+
+do_backup() {
+    if [ -d "$dest_dir" ] && [ "$(ls -A "$dest_dir" 2>/dev/null)" ]; then
+        rm -rf "$backup_dir"
+        mkdir -p "$(dirname "$backup_dir")"
+        cp -a "$dest_dir" "$backup_dir"
+        log "Backed up $dest_dir to $backup_dir"
+    else
+        # Mark that there was no previous content
+        rm -rf "$backup_dir"
+        mkdir -p "$backup_dir"
+        touch "$backup_dir/.was_empty"
+        log "No existing content to back up"
+    fi
+}
+
+do_install() {
+    local payload_dir
+    payload_dir="$FILES/files"
+
+    mkdir -p "$dest_dir"
+
+    # Copy all payload files except dest_dir marker
+    for item in "$payload_dir"/*; do
+        if [ -e "$item" ] && [ "$(basename "$item")" != "dest_dir" ]; then
+            cp -a "$item" "$dest_dir/"
+            log "Installed $(basename "$item") to $dest_dir"
+        fi
+    done
+
+    log "Installation complete to $dest_dir"
+}
+
+do_rollback() {
+    if [ -f "$backup_dir/.was_empty" ]; then
+        rm -rf "$dest_dir"
+        mkdir -p "$dest_dir"
+        log "Rolled back to empty state"
+    elif [ -d "$backup_dir" ] && [ "$(ls -A "$backup_dir" 2>/dev/null)" ]; then
+        rm -rf "$dest_dir"
+        cp -a "$backup_dir" "$dest_dir"
+        log "Rolled back to previous version"
+    else
+        log "No backup found, nothing to restore"
+    fi
+}
+
+do_cleanup() {
+    if [ -d "$backup_dir" ]; then
+        rm -rf "$backup_dir"
+        log "Cleaned up backup"
+    fi
+}
+
+case "$STATE" in
+    NeedsArtifactReboot)
+        echo "No"
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    ArtifactInstall)
+        log "Starting installation"
+        do_backup
+        if ! do_install; then
+            log "Installation failed, rolling back"
+            do_rollback
+            exit 1
+        fi
+        ;;
+
+    ArtifactCommit)
+        log "Committing update"
+        ;;
+
+    ArtifactRollback)
+        log "Rolling back"
+        do_rollback
+        ;;
+
+    ArtifactFailure)
+        log "Handling failure"
+        ;;
+
+    Cleanup)
+        log "Performing cleanup"
+        do_cleanup
+        ;;
+
+    *)
+        # Ignore unknown states
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
Adds an update module that deploys files to the persistent /data partition with rollback support. Uses --software-filesystem data-partition to ensure version tracking survives rootfs A/B updates.

Key features:
- Configurable destination directory via artifact metadata
- Full rollback support with automatic backup
- Preserves file ownership and permissions
- Artifact generator includes data-partition namespace automatically